### PR TITLE
Set up VFs prior to system network initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: python
 install: pip install tox-travis
 matrix:
   include:
-    - name: "Python 3.5"
-      python: 3.5
-      env: ENV=pep8,py3
     - name: "Python 3.6"
       python: 3.6
       env: ENV=pep8,py3

--- a/tools/sriov-netplan-shim.service
+++ b/tools/sriov-netplan-shim.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Configure SR-IOV VF functions on boot
 DefaultDependencies=no
-Before=network.target openvswitch-switch.service mlnx-switchdev-mode.service
-After=network-pre.target
+After=systemd-udevd.service
+Before=network-pre.target openvswitch-switch.service mlnx-switchdev-mode.service
+Wants=network-pre.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
When used together with the `mlnx-switchdev-mode` package we need
to do the initialization of VFs prior to netplan applying runtime
network system config. This is to be able to support any required
initialization before putting network interfaces into bonds etc.

https://community.mellanox.com/s/article/Configuring-VF-LAG-using-TC