### PR TITLE
Add support for matching devices on MAC or PCI address

### DIFF
--- a/etc/interfaces.yaml
+++ b/etc/interfaces.yaml
@@ -1,6 +1,20 @@
 # Example interfaces file for sriov-netplan-shim
+#
+# When the optional `match` dictionary is present and contains a `macaddress`
+# or `pciaddress` field, these fields will be used to locate the device rather
+# than the interface name. This is useful on systems where interface names are
+# unpredictable or changing names early in the boot sequence.
+#
 # interfaces:
 #     enp3s0f0:
 #         num_vfs: 64
 #     enp3s0f1:
+#         num_vfs: 64
+#     enp4s0f0:
+#         match:
+#           pciaddress: 0000:81:00.0
+#         num_vfs: 64
+#     enp4s0f1:
+#         match:
+#           macaddress: 00:53:00:00:00:42
 #         num_vfs: 64

--- a/sriov_netplan_shim/cmd.py
+++ b/sriov_netplan_shim/cmd.py
@@ -44,7 +44,16 @@ def configure():
     for interface_name in interfaces:
         num_vfs = interfaces[interface_name]["num_vfs"]
         devices = pci.PCINetDevices()
-        device = devices.get_device_from_interface_name(interface_name)
+        device = None
+        if 'match' in interfaces[interface_name]:
+            match = interfaces[interface_name]['match']
+            if 'macaddress' in match:
+                device = devices.get_device_from_mac(match['macaddress'])
+            elif 'pciaddress' in match:
+                device = devices.get_device_from_pci_address(
+                    match['pciaddress'])
+        else:
+            device = devices.get_device_from_interface_name(interface_name)
         if device and device.sriov:
             if num_vfs > device.sriov_totalvfs:
                 logging.warn(


### PR DESCRIPTION
When running this service early in the boot sequence the interface
names may be unpredictable. Add support for matching devices on
MAC address or PCI address.