### PR TITLE
pci: Allow discovery of VirtIO PCI netdevs

### DIFF
--- a/sriov_netplan_shim/pci.py
+++ b/sriov_netplan_shim/pci.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import glob
+import itertools
 import logging
 import os
 import re
@@ -56,7 +57,9 @@ def get_sysnet_interfaces_and_macs() -> list:
     :rtype: list
     """
     net_devs = []
-    for sdir in glob.glob("/sys/bus/pci/devices/*/net/../"):
+    for sdir in itertools.chain(
+            glob.glob("/sys/bus/pci/devices/*/net/../"),
+            glob.glob("/sys/bus/pci/devices/*/virtio*/net/../")):
         fq_path = os.path.realpath(sdir)
         path = fq_path.split("/")
         if "virtio" in path[-1]:

--- a/sriov_netplan_shim/tests/unit/test_pci.py
+++ b/sriov_netplan_shim/tests/unit/test_pci.py
@@ -111,7 +111,9 @@ class PCINetDeviceTest(CharmTestCase):
     def test_get_sysnet_interfaces_and_macs(
         self, _update, _interface, _mac, _state, _sriov, _osrealpath, _osislink
     ):
-        self.glob.glob.return_value = ["/sys/bus/pci/devices/0000:10:00.0"]
+        self.glob.glob.side_effect = (
+            ["/sys/bus/pci/devices/0000:10:00.0"],
+            [])
         _interface.return_value = "eth2"
         _mac.return_value = "a8:9d:21:cf:93:fc"
         _state.return_value = "up"
@@ -140,7 +142,9 @@ class PCINetDeviceTest(CharmTestCase):
     def test_get_sysnet_interfaces_and_macs_virtio(
         self, _update, _interface, _mac, _state, _sriov, _osrealpath, _osislink
     ):
-        self.glob.glob.return_value = ["/sys/bus/pci/devices/0000:10:00.0"]
+        self.glob.glob.side_effect = (
+            ["/sys/bus/pci/devices/0000:10:00.0"],
+            [])
         _interface.return_value = "eth2"
         _mac.return_value = "a8:9d:21:cf:93:fc"
         _state.return_value = "up"


### PR DESCRIPTION
The sysfs layout is slightly different for VirtIO netdevs.  Part
of the code already accounts for this, but the one that lists
the netdevs missed it.

We need this to be able to test for example DPDK in virtual
machines using the virtio PMD support.